### PR TITLE
Handle invalid response status

### DIFF
--- a/client/src/http_client/mod.rs
+++ b/client/src/http_client/mod.rs
@@ -84,6 +84,13 @@ impl HttpClient {
             response.await
         };
         let mut response = response.map_err(|err| err.into_inner())?;
+        if !response.status().is_success() {
+            log::debug!("HTTP response status {}", response.status());
+            return Err(HttpClientError::Http(anyhow::anyhow!(
+                "Unexpected response status code: {}",
+                response.status()
+            )));
+        }
 
         let response = response.body_string().await.map_err(|err| err.into_inner())?;
         log::debug!("Response: {}", response);


### PR DESCRIPTION
The current implementation doesn't handling non success response, If we got a non success reponse from server, http client will raise: `error: expected value at line 1 column 1`.
This PR checks the response status code and return a reasonable error if the code isn't 200.